### PR TITLE
Update ssgx cmake api

### DIFF
--- a/cmake/entrypoints/extract_mrenclave_entry.cmake
+++ b/cmake/entrypoints/extract_mrenclave_entry.cmake
@@ -1,0 +1,54 @@
+# extract_mrenclave_entry.cmake
+
+# ============================================================================================
+# Function: extract_mrenclave
+# Description: Extracts MRENCLAVE (enclave_hash) from sgx_sign dump file.
+#
+# Parameters:
+#   FILE               - Path to sgx_sign dump output file (e.g., enclave_dump.txt)
+#   OUT_MRENCLAVE_VAR  - Name of the CMake variable to receive the extracted MRENCLAVE hex string
+#
+# Example:
+#   extract_mrenclave(FILE <dump_file> OUT_MRENCLAVE_VAR <output_variable>)
+#   extract_mrenclave(FILE ${FILE} OUT_MRENCLAVE_VAR __mren_value)
+#   file(WRITE "${OUT}" "${__mren_value}")
+# ============================================================================================
+function(extract_mrenclave)
+    cmake_parse_arguments(MREN "" "FILE;OUT_MRENCLAVE_VAR" "" ${ARGN})
+    if(NOT MREN_FILE OR NOT MREN_OUT_MRENCLAVE_VAR)
+        message(FATAL_ERROR "Usage: extract_mrenclave(FILE <dump.txt> OUT_MRENCLAVE_VAR <var>)")
+    endif()
+
+    file(READ "${MREN_FILE}" _dump_content)
+    string(REPLACE "\n" ";" _lines "${_dump_content}")
+
+    set(_found_hash FALSE)
+    set(_hash_line_count 0)
+    set(_mren_lines "")
+
+    foreach(line IN LISTS _lines)
+        if(_found_hash)
+            if(_hash_line_count LESS 2)
+                string(APPEND _mren_lines "${line}")
+                math(EXPR _hash_line_count "${_hash_line_count} + 1")
+            endif()
+        endif()
+
+        if(line MATCHES "enclave_css\\.body\\.enclave_hash\\.m:")
+            set(_found_hash TRUE)
+        endif()
+    endforeach()
+
+    string(REPLACE "0x" "" _mren_lines "${_mren_lines}")
+    string(REPLACE "," "" _mren_lines "${_mren_lines}")
+    string(REPLACE " " "" _mren_lines "${_mren_lines}")
+
+    set(${MREN_OUT_MRENCLAVE_VAR} "${_mren_lines}" PARENT_SCOPE)
+    message(STATUS "[extract_mrenclave] MRENCLAVE: ${_mren_lines}")
+endfunction()
+
+if(DEFINED FILE AND DEFINED OUT_MRENCLAVE_VAR)
+    extract_mrenclave(FILE ${FILE} OUT_MRENCLAVE_VAR ${OUT_MRENCLAVE_VAR})
+else()
+    message(FATAL_ERROR "FILE and OUT_MRENCLAVE_VAR must be defined.")
+endif()

--- a/cmake/internal/ssgx-deps.cmake
+++ b/cmake/internal/ssgx-deps.cmake
@@ -27,6 +27,11 @@ function(ssgx_collect_dependencies target output_list)
         return()
     endif()
 
+    if(${target} MATCHES "^-l")
+        list(APPEND collected_deps ${dep})
+        return()
+    endif()
+
     get_target_property(deps ${target} INTERFACE_LINK_LIBRARIES)
     if (deps)
         foreach(dep ${deps})

--- a/cmake/internal/ssgx-env.cmake
+++ b/cmake/internal/ssgx-env.cmake
@@ -27,6 +27,10 @@
 #
 # - SSGX_ENV__HARDWARE_MODE          : ON / OFF
 #     -> Set via `ssgx_set_hardware_mode(...)`
+#
+# [4] entry path
+# -----------------------------------------------------
+# - SSGX_ENV__CMAKE_ENTRY_PATH
 # ============================================================================================
 
 include_guard(GLOBAL)
@@ -127,6 +131,9 @@ ssgx_check_path("${SSGX_ENV__SGXSSL_LIBRARY_DIR}/libsgx_tsgxssl.a" "Intel SGX SS
 # Section 6: Define global EDL search paths (used by sgx_edger8r)
 # ============================================================================================
 set(SSGX_ENV__EDL_SEARCH_PATHS ${SSGX_ENV__SGXSDK}/include /opt/safeheron/ssgx/include/mbedtls CACHE PATH "Search Paths for SSGX EDL files" FORCE)
+
+
+set(SSGX_ENV__CMAKE_ENTRY_PATH ${CMAKE_CURRENT_LIST_DIR}/../entrypoints CACHE PATH "CMAKE_ENTRY_PATH of SSGX" FORCE)
 
 # ============================================================================================
 # Section 7: Enum Setup: BuildMode {Debug, PreRelease, Release}

--- a/cmake/internal/ssgx-sign.cmake
+++ b/cmake/internal/ssgx-sign.cmake
@@ -66,6 +66,9 @@ function(ssgx_sign_enclave target)
     )
 
     add_custom_target(${target}-signed ALL
+            COMMAND ${SSGX_ENV__SGX_ENCLAVE_SIGNER} dump -enclave ${OUTPUT_NAME} -dumpfile ${target}-signed-metadata.txt
+            COMMAND ${CMAKE_COMMAND} -DFILE=${target}-signed-metadata.txt -DOUT_MRENCLAVE_VAR=__unused -P ${SSGX_ENV__CMAKE_ENTRY_PATH}/extract_mrenclave_entry.cmake
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
             DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${OUTPUT_NAME}
     )
 

--- a/cmake/internal/ssgx-utils.cmake
+++ b/cmake/internal/ssgx-utils.cmake
@@ -117,7 +117,7 @@ endfunction()
 #   KEY_FILE_PATH (Required): The full path to the private key file to check or create.
 #   KEY_SIZE (Optional): The number of bits to use when generating the key (Default: 3072).
 #   OPENSSL_EXE (Optional): The path to the openssl executable. If not provided, it will be searched for automatically.
-#
+# ============================================================================================
 function(ssgx_ensure_rsa_key_exists)
     # Define the arguments accepted by the function
     set(options "") # No boolean options

--- a/ssgx/CMakeLists.txt
+++ b/ssgx/CMakeLists.txt
@@ -35,3 +35,4 @@ install(DIRECTORY ../common/include/
 
 install(FILES ../cmake/ssgx-build.cmake DESTINATION lib/cmake/ssgx)
 install(DIRECTORY ../cmake/internal DESTINATION lib/cmake/ssgx)
+install(DIRECTORY ../cmake/entrypoints DESTINATION lib/cmake/ssgx)


### PR DESCRIPTION
Update SSGX CMake API

- Enhance ssgx_sign_enclave to automatically output the enclave's MRENCLAVE after a successful build.

- Updated the installation script.

- Added an environment variable: SSGX_ENV__CMAKE_ENTRY_PATH

- Supports importing third-party libraries using the following format: -lxxxx
ssgx_add_untrusted_executable(${app}
		SRCS host.cpp
		EDL Enclave.edl
		EDL_SEARCH_PATHS ../ ${ssgx_EDL_DIRS}
		UNTRUSTED_LIBS
			ssgx::ssgx_http_u
			ssgx::ssgx_log_u
			ssgx::ssgx_config_u
			ssgx::ssgx_utils_u
			ssgx::ssgx_filesystem_u
			ssgx::ssgx_attestation_u
			-lmysqlpp
)