### PR TITLE
Feature/v1.3.1 compact sgx2.23

### DIFF
--- a/cmake/internal/ssgx-env.cmake
+++ b/cmake/internal/ssgx-env.cmake
@@ -82,6 +82,8 @@ ssgx_check_variable_path(SSGX_ENV__SGXSDK_INCLUDE_DIR "SGX include directory")
 ssgx_check_path("${SSGX_ENV__SGXSDK_LIBRARY_DIR}/libsgx_urts.so" "SGX SDK library")
 ssgx_check_path("${SSGX_ENV__SGXSDK_INCLUDE_DIR}/sgx.h" "SGX SDK header file")
 
+include("${CMAKE_CURRENT_LIST_DIR}/ssgx-sdk-version.cmake")
+
 # ============================================================================================
 # Section 3: Include directories for SGX SDK  (tlibc, libcxx, protobuf)
 # - SSGX_ENV__SGXSDK_INCLUDE_DIRS

--- a/cmake/internal/ssgx-sdk-version.cmake
+++ b/cmake/internal/ssgx-sdk-version.cmake
@@ -1,0 +1,26 @@
+# ==============================================================================
+# ssgx-sdk-version.cmake
+#
+# Detects SGX SDK version via sgx_sign and defines SGXSDK_VERSION_MAJOR and
+# SGXSDK_VERSION_MINOR as global compile definitions for version-gated code.
+#
+# Requires: SSGX_ENV__SGX_ENCLAVE_SIGNER must be set before including this file.
+# ==============================================================================
+
+execute_process(
+    COMMAND ${SSGX_ENV__SGX_ENCLAVE_SIGNER} -version
+    OUTPUT_VARIABLE _sgx_sign_ver_output
+    ERROR_VARIABLE  _sgx_sign_ver_output
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+string(REGEX MATCH "version ([0-9]+)\\.([0-9]+)" _ "${_sgx_sign_ver_output}")
+set(_sgx_major ${CMAKE_MATCH_1})
+set(_sgx_minor ${CMAKE_MATCH_2})
+if(NOT _sgx_major OR NOT _sgx_minor)
+    message(FATAL_ERROR "[SSGX] Failed to detect SGX SDK version from sgx_sign output:\n${_sgx_sign_ver_output}")
+endif()
+message(STATUS "[SSGX] SGX SDK version: ${_sgx_major}.${_sgx_minor}")
+add_compile_definitions(SGXSDK_VERSION_MAJOR=${_sgx_major} SGXSDK_VERSION_MINOR=${_sgx_minor})
+unset(_sgx_sign_ver_output)
+unset(_sgx_major)
+unset(_sgx_minor)

--- a/common/include/ssgx_attestation_share.h
+++ b/common/include/ssgx_attestation_share.h
@@ -69,6 +69,10 @@ enum class ErrorCode : uint32_t {
     /// The actual size of supplemental data did not match the expected value.
     SupplementSizeIsWrong = 0x0014,
 
+    /// The requested operation mode is not supported by this library.
+    /// Currently raised when out-of-process AESM mode (SGX_AESM_ADDR) is detected.
+    ModeNotSupported = 0x0015,
+
     /// An unspecified or unexpected error occurred.
     Unknown = 0xFFFF
 };

--- a/common/include/ssgx_attestation_share.h
+++ b/common/include/ssgx_attestation_share.h
@@ -132,7 +132,10 @@ enum class QvResult : uint32_t {
 
     /// Corresponds to SGX_QL_QV_RESULT_TD_RELAUNCH_ADVISED_CONFIG_NEEDED.
     /// For TDX: Same as above, and additional platform configuration is also required.
+    /// Available since SGX SDK 2.24.
+#if SGXSDK_VERSION_MAJOR > 2 || (SGXSDK_VERSION_MAJOR == 2 && SGXSDK_VERSION_MINOR >= 24)
     TDRelaunchAdvisedConfigNeeded = 0xA00A,
+#endif
 
     /// Corresponds to SGX_QL_QV_RESULT_MAX.
     /// Maximum defined SGX QVL result value.

--- a/common/include/ssgx_utils_t.edl
+++ b/common/include/ssgx_utils_t.edl
@@ -23,7 +23,7 @@ enclave {
 
         void ssgx_ocall_calloc( size_t num, size_t size, [out] uint8_t **pptr_outside_enclave );
 
-        void ssgx_ocall_free( [in] uint8_t* ptr_outside_enclave );
+        void ssgx_ocall_free( [user_check] uint8_t* ptr_outside_enclave );
 
         void ssgx_ocall_sleep(uint32_t seconds);
     };

--- a/ssgx/attestation/t/RemoteAttestor.cpp
+++ b/ssgx/attestation/t/RemoteAttestor.cpp
@@ -49,8 +49,10 @@ static inline sgx_ql_qv_result_t FromQvResult(QvResult val) {
         return SGX_QL_QV_RESULT_CONFIG_AND_SW_HARDENING_NEEDED;
     case QvResult::TDRelaunchAdvised:
         return SGX_QL_QV_RESULT_TD_RELAUNCH_ADVISED;
+#if SGXSDK_VERSION_MAJOR > 2 || (SGXSDK_VERSION_MAJOR == 2 && SGXSDK_VERSION_MINOR >= 24)
     case QvResult::TDRelaunchAdvisedConfigNeeded:
         return SGX_QL_QV_RESULT_TD_RELAUNCH_ADVISED_CONFIG_NEEDED;
+#endif
     }
     throw std::runtime_error("Invalid QvResult value");
 }

--- a/ssgx/attestation/u/RemoteAttestor.cpp
+++ b/ssgx/attestation/u/RemoteAttestor.cpp
@@ -39,8 +39,10 @@ static inline sgx_ql_qv_result_t FromQvResult(QvResult val) {
         return SGX_QL_QV_RESULT_CONFIG_AND_SW_HARDENING_NEEDED;
     case QvResult::TDRelaunchAdvised:
         return SGX_QL_QV_RESULT_TD_RELAUNCH_ADVISED;
+#if SGXSDK_VERSION_MAJOR > 2 || (SGXSDK_VERSION_MAJOR == 2 && SGXSDK_VERSION_MINOR >= 24)
     case QvResult::TDRelaunchAdvisedConfigNeeded:
         return SGX_QL_QV_RESULT_TD_RELAUNCH_ADVISED_CONFIG_NEEDED;
+#endif
     }
     throw std::runtime_error("Invalid QvResult value");
 }

--- a/ssgx/attestation/u/ocall_attestation.cpp
+++ b/ssgx/attestation/u/ocall_attestation.cpp
@@ -27,10 +27,10 @@ extern "C" int ssgx_ocall_get_qe_target_info(sgx_target_info_t* p_qe3_target) {
         return static_cast<int>(ErrorCode::InvalidParameter);
     }
 
-    // Check AESM server, if it is available, set is_out_of_proc = true
+    // Out-of-process mode (AESM service via socket) is not supported.
     const char *out_of_proc = getenv(SGX_AESM_ADDR);
-    if (!out_of_proc) {
-        is_out_of_proc = true;
+    if (out_of_proc) {
+        return static_cast<int>(ErrorCode::ModeNotSupported);
     }
 
     // Initialize QE libraries,

--- a/ssgx/filesystem/t/ProtectedFileWriter.cpp
+++ b/ssgx/filesystem/t/ProtectedFileWriter.cpp
@@ -120,7 +120,7 @@ static SGX_FILE* OpenFileForAppend(const char* file_name, const char* meta_file_
             throw FileSystemException("Invalid metadata file, key_policy and legacy mode are not consistent");
         }
         if (key_request.isv_svn != report->body.isv_svn ||
-            memcmp(&key_request.cpu_svn, &report->body.cpu_svn, sizeof(sgx_isv_svn_t) ) != 0) {
+            memcmp(&key_request.cpu_svn, &report->body.cpu_svn, sizeof(sgx_cpu_svn_t)) != 0) {
             throw FileSystemException("A file with the same name already exists and was created by another enclave.");
         }
     }


### PR DESCRIPTION
 feat: SGX SDK version detection and bug fixes for v1.3.1 compatibility

 1. cmake: add SGX SDK version detection
    - Add cmake/internal/ssgx-sdk-version.cmake: probe sgx_sign -version
      and expose SGXSDK_VERSION_MAJOR/MINOR as global compile definitions;
      fatal error if detection fails
    - Use numeric version guards to conditionally compile
      TDRelaunchAdvisedConfigNeeded, enabling builds against SGX SDK 2.23
      while retaining full support on 2.24+

 2. attestation: fix out_of_proc detection and add ModeNotSupported code
    - Fix inverted condition: !out_of_proc → out_of_proc
    - Add ErrorCode::ModeNotSupported (0x0015); returned when SGX_AESM_ADDR
      is set (out-of-process AESM mode is not supported)

 3. EDL: fix ssgx_ocall_free [in] → [user_check]
    - [in] caused edger8r to free a 1-byte temp copy instead of the
      original pointer, leaking all freed outside-enclave memory

 4. filesystem: fix memcmp size for cpu_svn comparison
    - sizeof(sgx_isv_svn_t) (2 bytes) → sizeof(sgx_cpu_svn_t) (16 bytes)